### PR TITLE
Route overwriting fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -960,7 +960,7 @@ Framework.prototype.route = function(url, funcExecute, flags, length, middleware
 	if (name[1] === '#')
 		name = name.substring(1);
 
-	self.routes.web.push({
+	var newRoute = {
 		name: name,
 		priority: priority,
 		schema: schema,
@@ -993,7 +993,24 @@ Framework.prototype.route = function(url, funcExecute, flags, length, middleware
 		isUPLOAD: flags.indexOf('upload') !== -1,
 		isSYSTEM: url.startsWith('/#'),
 		options: options
-	});
+	}
+	    
+	var found = false;
+	for(var i=0;i<self.routes.web.length;i++){
+	        var r = self.routes.web[i];
+	        if(r.url.toString()==newroute.url.toString()){
+	            // Found it
+	            found = true;
+	            self.routes.web[i] = newroute;
+	            return;
+	        }
+	 }
+	    
+	if(!found){
+	        self.routes.web.push(newroute);
+	}
+
+	self.routes.web.push();
 
 	self.emit('route-add', 'web', self.routes.web[self.routes.web.length - 1]);
 

--- a/index.js
+++ b/index.js
@@ -1010,8 +1010,6 @@ Framework.prototype.route = function(url, funcExecute, flags, length, middleware
 	        self.routes.web.push(newroute);
 	}
 
-	self.routes.web.push();
-
 	self.emit('route-add', 'web', self.routes.web[self.routes.web.length - 1]);
 
 	if (_controller.length === 0)


### PR DESCRIPTION
Small change that allows the route to be overwritten. Current behavior:
F.route('/',view_index);  
F.route('/',view_index2);

Even though we're specifying route for the 2nd time with view_index2, view_index 1 will always be used. Routes keep getting pushed into an array and right now it's 1st come 1st serve. So this fix checks if route with that destination is already in place and overwrites it.
